### PR TITLE
SRV-1578: Stripping whitespaces from PRs names

### DIFF
--- a/lib/scenarios/deployrelease.rb
+++ b/lib/scenarios/deployrelease.rb
@@ -15,6 +15,18 @@ module Scenarios
       labels = labels.uniq
 
       prs = issue.related['pullRequests']
+
+      puts 'Checking for wrong PRs names:'
+
+      prs.each do |pr|
+        prname = pr['name'].dup
+        if pr['name'].strip!.nil?
+          puts "[#{prname}] - OK"
+        else
+          puts "[#{prname}] - WRONG! Stripped. Bad guy: #{pr['author']['name']}"
+        end
+      end
+
       git_style_release = SimpleConfig.jira.issue.tr('-', ' ').downcase.capitalize
 
       prs.select! { |pr| (/^((#{SimpleConfig.jira.issue})|(#{git_style_release}))/.match pr['name']) && pr['status'] != 'DECLINED' }
@@ -24,6 +36,7 @@ module Scenarios
         exit 1
       end
 
+      puts 'Selected PRs:'
       puts prs.map { |pr| pr['name'] }
       pp prs
 


### PR DESCRIPTION
https://onetwotripdev.atlassian.net/browse/SRV-1578

Checking for wrong PRs names:
[OTT-9944 release 24.08.2016 12trip] - OK
[FE-1100-f-old-typo-error] - OK
[FE-1099-f-old-amex-bug] - OK
[FE-1135-revert-merge] - OK
[FE-899-vas-text-test--for-merge] - OK
[OTT-9944 release 24.08.2016 12trip xjsx] - OK
[OTT-9567 cr nan value] - OK
[OTT-9944 release 24.08.2016 avia] - OK
[OTT-9944 release 24.08.2016 bo] - OK
[ OTT-9944 release 24.08.2016 tlive] - WRONG! Stripped. Bad guy: Alexey Sutiagin
[OTT-9944 release 24.08.2016 seo] - OK
Selected PRs:
OTT-9944 release 24.08.2016 12trip
OTT-9944 release 24.08.2016 12trip xjsx
OTT-9944 release 24.08.2016 avia
OTT-9944 release 24.08.2016 bo
OTT-9944 release 24.08.2016 tlive
OTT-9944 release 24.08.2016 seo