### PR TITLE
displaying release name on 'createrelease'

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -20,6 +20,19 @@ module Ott
       puts "#{diff}\n Diff without marks or unknown marks!" if ranges.empty? && !diff.empty?
       ranges
     end
+
+    # export any data for Jenkins later use
+    def self.export_to_file(data, custom_filename = nil)
+      file_name = custom_filename || 'ruby_script_output.txt'
+      file_path = File.join(@root, file_name)
+
+      LOGGER.info "Exporting to #{file_path}"
+      # creating file in root, overwriting anything
+      File.open(file_path, 'w+') do |file|
+        file << data
+      end
+      LOGGER.info "Exported #{File.size(file_path)} bytes to '#{file_path}'"
+    end
   end
 
   # This module represents CheckBranchesBuildStatuses

--- a/lib/scenarios/createrelease.rb
+++ b/lib/scenarios/createrelease.rb
@@ -6,7 +6,7 @@ module Scenarios
       issue.jql("filter=#{filter}")
     rescue JIRA::HTTPError => jira_error
       error_message = jira_error.response['body_exists'] ? jira_error.message : jira_error.response.body
-      puts "Error in JIRA with the search by filter #{error_message}".red
+      LOGGER.error "Error in JIRA with the search by filter #{error_message}"
       []
     end
 
@@ -20,7 +20,7 @@ module Scenarios
         rescue JIRA::HTTPError => jira_error
           error_message = jira_error.response['body_exists'] ? jira_error.message : jira_error.response.body
 
-          puts "Error in JIRA with the search by issue key #{error_message}".red
+          LOGGER.error "Error in JIRA with the search by issue key #{error_message}"
         end
       end
 
@@ -36,7 +36,7 @@ module Scenarios
       release
     rescue JIRA::HTTPError => jira_error
       error_message = jira_error.response['body_exists'] ? jira_error.message : jira_error.response.body
-      puts "Creation of release was failed with error #{error_message}".red
+      LOGGER.error "Creation of release was failed with error #{error_message}"
       raise error_message
     end
 
@@ -45,16 +45,16 @@ module Scenarios
       params = SimpleConfig.release
 
       unless params
-        puts 'No Release params in ENV'.red
+        LOGGER.error 'No Release params in ENV'
         exit
       end
 
       if !params.filter && !params.tasks
-        puts 'No necessary params - filter of tasks'.red
+        LOGGER.error 'No necessary params - filter of tasks'
         exit
       end
 
-      puts "Create release from filter #{params[:filter]} with name #{params[:name]}".green
+      LOGGER.info "Create release from filter #{params[:filter]} with name #{params[:name]}"
 
       client = JIRA::Client.new SimpleConfig.jira.to_h
 
@@ -71,11 +71,13 @@ module Scenarios
         exit
       end
 
-      puts "Start to link issues to release #{release.key}".green
+      LOGGER.info "Start to link issues to release #{release.key}"
 
       issues.each { |issue| issue.link(release.key) }
 
-      puts "Create new release #{release.key} from filter #{params[:filter]}".green
+      LOGGER.info "Created new release #{release.key} from filter #{params[:filter]}"
+      LOGGER.info "Storing '#{release.key}' to file, to refresh buildname in Jenkins"
+      Ott::Helpers.export_to_file(release.key, 'release_name.txt')
     end
     # :nocov:
   end

--- a/spec/lib/helpers_spec.rb
+++ b/spec/lib/helpers_spec.rb
@@ -14,4 +14,16 @@ describe Ott::Helpers do
     BODY
     expect(Ott::Helpers.diffed_lines(diff)).to match_array [38..45, 56..62]
   end
+
+  it 'stores data to local file' do
+    some_data       = 'OTT-12' # sample issue
+    custom_filename = 'some_file2.txt'
+    full_path       = File.join(Dir.pwd, custom_filename)
+    double          = StringIO.new
+    allow(File).to receive(:open).with(full_path, 'w+').and_yield(double)
+    allow(File).to receive(:size).with(full_path)
+
+    Ott::Helpers.export_to_file(some_data, custom_filename)
+    expect(double.string).to eq(some_data)
+  end
 end


### PR DESCRIPTION
I need the Jira issue name to be updated as a build name after release creation.
So the only way of getting that name from Ruby is to store data locally for Jenkins.

Here I go:  
- helper to store data for jenkins use
- puts -> LOGGER
- test