### PR TITLE
add new failure step

### DIFF
--- a/lib/scenarios/createrelease.rb
+++ b/lib/scenarios/createrelease.rb
@@ -67,8 +67,10 @@ module Scenarios
 
       begin
         release = create_release_issue(client.Project, client.Issue, params[:project], params[:name])
-      rescue RuntimeError
-        exit
+      rescue RuntimeError => e
+        puts e.message
+        puts e.backtrace.inspect
+        raise
       end
 
       LOGGER.info "Start to link issues to release #{release.key}"


### PR DESCRIPTION
This raise need for case when jira return some errors, but task doesn't stop and continue executing. Build will be mark as success, but it's definitely not